### PR TITLE
feat(tabs): add tabs using simple context

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -1,0 +1,44 @@
+import * as React from 'react'
+
+const TabsContext = React.createContext()
+
+function TabPanel({children}) {
+  return <div>{children}</div>
+}
+
+function TabPanels({children, ...props}) {
+  const [activeIndex] = React.useContext(TabsContext)
+  return (
+    <div>
+      {children.map((panel, idx) => (idx === activeIndex ? panel : null))}
+    </div>
+  )
+}
+
+function Tab({children: child, onClick}) {
+  return <button onClick={onClick}>{child}</button>
+}
+
+function TabList({children, ...props}) {
+  const [, setState] = React.useContext(TabsContext)
+  return React.Children.map(children, (child, index) => {
+    return React.cloneElement(child, {
+      key: `tab-${index}`,
+      onClick: () => {
+        setState(index)
+        child.props?.onClick && child.props.onClick()
+      },
+    })
+  })
+}
+
+function Tabs({children, ...props}) {
+  const [state, setState] = React.useState(0)
+  return (
+    <TabsContext.Provider value={[state, setState]} {...props}>
+      {children}
+    </TabsContext.Provider>
+  )
+}
+
+export {Tabs, TabList, Tab, TabPanel, TabPanels}

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -1,37 +1,28 @@
 import * as React from 'react'
 
 const TabsContext = React.createContext()
-
-function TabPanel({children}) {
-  return <div>{children}</div>
-}
-
-function TabPanels({children, ...props}) {
-  const [activeIndex] = React.useContext(TabsContext)
-  return (
-    <div>
-      {children.map((panel, idx) => (idx === activeIndex ? panel : null))}
-    </div>
-  )
-}
-
-function Tab({children: child, onClick}) {
-  return <button onClick={onClick}>{child}</button>
-}
-
-function TabList({children, ...props}) {
-  const [, setState] = React.useContext(TabsContext)
-  return React.Children.map(children, (child, index) => {
-    return React.cloneElement(child, {
-      key: `tab-${index}`,
-      onClick: () => {
-        setState(index)
-        child.props?.onClick && child.props.onClick()
-      },
-    })
-  })
-}
-
+/**
+ * A declarative and bare bones Tabs component usage:
+ * <Tabs>
+ *  <TabList>
+ *    <Tab>1</Tab>
+ *    <Tab>2</Tab>
+ *    <Tab>3</Tab>
+ *  </TabList>
+ *
+ *  <TabPanels>
+ *    <TabPanel>
+ *      <p>one!</p>
+ *    </TabPanel>
+ *    <TabPanel>
+ *      <p>two!</p>
+ *    </TabPanel>
+ *    <TabPanel>
+ *      <p>three!</p>
+ *    </TabPanel>
+ *  </TabPanels>
+ * </Tabs>
+ */
 function Tabs({children, ...props}) {
   const [state, setState] = React.useState(0)
   return (
@@ -39,6 +30,42 @@ function Tabs({children, ...props}) {
       {children}
     </TabsContext.Provider>
   )
+}
+
+function TabList({children, ...props}) {
+  const [, setState] = React.useContext(TabsContext)
+  return React.Children.map(children, (child, index) => {
+    // clone each child with an additional onClick to set the active index
+    return React.cloneElement(child, {
+      key: `tab-${index}`,
+      onClick: () => {
+        setState(index)
+        // so we don't forget to call any onClick passed to the <Tab />!
+        child.props?.onClick && child.props.onClick()
+      },
+    })
+  })
+}
+
+function Tab({children: child, onClick, ...props}) {
+  return (
+    <button {...props} onClick={onClick}>
+      {child}
+    </button>
+  )
+}
+
+function TabPanels({children, ...props}) {
+  const [activeIndex] = React.useContext(TabsContext)
+  return (
+    <div {...props}>
+      {children.map((panel, idx) => (idx === activeIndex ? panel : null))}
+    </div>
+  )
+}
+
+function TabPanel({children, ...props}) {
+  return <div {...props}>{children}</div>
 }
 
 export {Tabs, TabList, Tab, TabPanel, TabPanels}

--- a/src/screens/main.js
+++ b/src/screens/main.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {xl, lg} from '../styles/sizes'
 import {Row, Column} from '../components/lib'
+import {Tabs, TabList, Tab, TabPanels, TabPanel} from '../components/tabs'
 
 function Main() {
   return (
@@ -15,7 +16,25 @@ function Main() {
         sed do eiusmod tempor incididunt ut labore et dolore
       </p>
       <div>
-        <div>This will contain our tab headers</div>
+        <Tabs>
+          <TabList>
+            <Tab>1</Tab>
+            <Tab>2</Tab>
+            <Tab>3</Tab>
+          </TabList>
+
+          <TabPanels>
+            <TabPanel>
+              <p>one!</p>
+            </TabPanel>
+            <TabPanel>
+              <p>two!</p>
+            </TabPanel>
+            <TabPanel>
+              <p>three!</p>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
         <Column gap="$lg">
           <Row gap="$lg">
             <div>Box with fixed height</div>


### PR DESCRIPTION
This PR adds a bare bones `<Tabs />` component using compound components with simple context. 
![2021-05-26 02 00 05](https://user-images.githubusercontent.com/17459422/119632970-22cd8280-bdc6-11eb-9a01-600c22d2efb9.gif)


```jsx
<Tabs>
  <TabList>
    <Tab>1</Tab>
    <Tab>2</Tab>
    <Tab>3</Tab>
  </TabList>

  <TabPanels>
    <TabPanel>
      <p>one!</p>
    </TabPanel>
    <TabPanel>
      <p>two!</p>
    </TabPanel>
    <TabPanel>
      <p>three!</p>
    </TabPanel>
  </TabPanels>
</Tabs>
```

The `<TabList />` leverages the index of each `Tab` to clone it with an additional `onClick` prop, which will set that index as the state value in the `TabsContext`. The `<TabPanels />` grabs that index value from context in order to figure out which child to render.
